### PR TITLE
Add TCP <-> USB bridge mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ FLAGS += -std=c99 -Wall -Wextra -DVERSION='"$(VERSION)"'
 SRCDIR = src
 OBJDIR = build
 
-SRCS = src/main.c src/packets.c src/run.c src/info.c src/up.c src/ls.c src/rm.c src/mkdir.c src/mkrbf.c src/dl.c src/listen.c src/send.c src/tunnel.c src/tcp.c src/bridge.c
+SRCS = src/main.c src/packets.c src/run.c src/info.c src/up.c src/ls.c src/rm.c src/mkdir.c src/mkrbf.c src/dl.c src/listen.c src/send.c src/tunnel.c src/tcp.c
 
 INC += -Ihidapi/ -Ihidapi/hidapi/
  
@@ -79,7 +79,8 @@ endif
 endif
 
 ## ALL UNICES
-SRCS += src/bt-unix.c
+FLAGS += -DBRIDGE_MODE
+SRCS += src/bt-unix.c src/bridge.c
 endif
 
 CROSS_PREFIX ?= arm-linux-gnueabi-g

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ FLAGS += -std=c99 -Wall -Wextra -DVERSION='"$(VERSION)"'
 SRCDIR = src
 OBJDIR = build
 
-SRCS = src/main.c src/packets.c src/run.c src/info.c src/up.c src/ls.c src/rm.c src/mkdir.c src/mkrbf.c src/dl.c src/listen.c src/send.c src/tunnel.c src/tcp.c
+SRCS = src/main.c src/packets.c src/run.c src/info.c src/up.c src/ls.c src/rm.c src/mkdir.c src/mkrbf.c src/dl.c src/listen.c src/send.c src/tunnel.c src/tcp.c src/bridge.c
 
 INC += -Ihidapi/ -Ihidapi/hidapi/
  

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -1,5 +1,5 @@
 /*
- * LEGOÃÂÃÂ® MINDSTORMS EV3
+ * LEGO® MINDSTORMS EV3
  *
  * Copyright (C) 2010-2013 The LEGO Group
  *
@@ -17,6 +17,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
  * USA.
+ */
+
+/*
+ * Note: This is a heavily stripped down and edited version of
+ * https://github.com/mindboards/ev3sources/blob/master/lms2012/c_com/source/c_wifi.c
  */
 
 #include <time.h>
@@ -369,7 +374,7 @@ static bool cNetInitUdp(void) {
 	return true;
 }
 
-int bridgeMode() {
+int bridge_mode() {
 	if (!cNetInitUdp()) return ERR_IO;
 	if (!cNetInitTcpServer()) return ERR_IO;
 

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -1,0 +1,442 @@
+/*
+ * LEGOÃÂÃÂ® MINDSTORMS EV3
+ *
+ * Copyright (C) 2010-2013 The LEGO Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+#include <time.h>
+#include <string.h>
+#include <assert.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <errno.h>
+#include <ctype.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/select.h>
+
+#include "ev3_io.h"
+#include "error.h"
+
+#define NDEBUG
+
+#define BROADCAST_ADDRESS "127.0.0.1"
+#define BROADCAST_PORT 3015
+#define TCP_PORT 5555
+#define BEACON_TIME 1
+#define BRICK_NAME "USB Bridge"
+
+typedef enum {
+  TCP_NOT_CONNECTED,    // Waiting for the PC to connect via TCP
+  TCP_CONNECTED,        // We have a TCP connection established
+  CLOSED                // UDP/TCP closed
+} NET_STATE;
+
+typedef enum {
+  TCP_IDLE                = 0x00,
+  TCP_WAIT_ON_START       = 0x01,
+  TCP_WAIT_ON_LENGTH      = 0x02,
+  TCP_WAIT_ON_ONLY_CHUNK  = 0x08,
+} TCP_CSTATE;
+
+static struct {
+	NET_STATE NetConnection;
+	TCP_CSTATE TcpRead;
+} State = {CLOSED, TCP_IDLE};
+
+// UDP
+static int UdpSocketDescriptor = 0;
+static int TcpConnectionSocket = 0; /*  connection socket         */
+static int TCPListenServer = 0;
+static uint32_t TcpReadBufPointer = 0;
+static uint32_t TcpTotalLength = 0;
+static uint32_t TcpRestLen = 0;
+
+#ifndef NDEBUG
+#define debug_printf(fmt, ...) do { \
+		fprintf(stderr, "%s:%i: " fmt "  \t[%s]\n", \
+		        __FILE__, __LINE__, ##__VA_ARGS__, __FUNCTION__); \
+	} while(0)
+#else
+#define debug_printf(...)
+#endif
+
+#define setState(x, y) do { if ((State.x) != (y)) {                      \
+			debug_printf("⎯⎯⎯⎯⎯⎯ %s => %s", #x, #y); (State.x) = (y); }} while(0)
+
+
+// ******************************************************************************
+
+static time_t start = 0;
+static void cNetStartTimer() {
+    start = time(NULL);
+}
+
+static unsigned cNetCheckTimer() {
+	return time(NULL) - start;
+}
+
+static void cNetTcpClose() {
+	int res;
+	uint8_t buffer[128];
+
+	struct linger so_linger;
+
+	so_linger.l_onoff = 1;
+	so_linger.l_linger = 0;
+	setsockopt(TcpConnectionSocket, SOL_SOCKET, SO_LINGER, &so_linger,
+	           sizeof so_linger);
+
+	if (shutdown(TcpConnectionSocket, 2) < 0) {
+		do {
+			debug_printf("In the do_while");
+			res = read(TcpConnectionSocket, buffer, 100);
+			if (res < 0) break;
+		} while (res != 0);
+        debug_printf("Error calling Tcp shutdown()");
+	}
+
+	TcpConnectionSocket = 0;
+	setState(NetConnection, TCP_NOT_CONNECTED);
+}
+
+static void cNetUdpClose(void) {
+	setState(NetConnection, CLOSED);
+	close(UdpSocketDescriptor);
+}
+
+static bool cNetInitTcpServer() {
+	setState(TcpRead, TCP_IDLE);
+	debug_printf("TCPListenServer = %d ", TCPListenServer);
+
+	if (TCPListenServer == 0) {
+		debug_printf("TCPListenServer == 0");
+
+		if ((TCPListenServer = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+			debug_printf("Error creating listening socket");
+			return false;
+		}
+
+		struct sockaddr_in servaddr = {};
+		servaddr.sin_family = AF_INET;                // IPv4
+		servaddr.sin_addr.s_addr = htonl(INADDR_ANY); // Any address
+		servaddr.sin_port = htons(TCP_PORT);
+
+		int Temp = fcntl(TCPListenServer, F_GETFL, 0);
+
+		fcntl(TCPListenServer, F_SETFL, Temp | O_NONBLOCK);
+
+		int SetOn = 1;
+		Temp = setsockopt(TCPListenServer, SOL_SOCKET, SO_REUSEADDR,
+		                  &SetOn, sizeof(SetOn));
+
+		if (bind(TCPListenServer, (struct sockaddr *)&servaddr,
+		         sizeof(servaddr)) < 0) {
+			debug_printf("Error calling bind(), errno = %i", errno);
+			return false;
+		}
+	}
+
+	if (listen(TCPListenServer, 1) < 0) {
+		debug_printf("Error calling listen()");
+		return false;
+	}
+
+	debug_printf("WAITING for a CLIENT.......");
+	return true;
+}
+
+static bool cNetWaitForTcpConnection(void) {
+	// blindly wait for up to 1 second
+	struct timeval ReadTimeVal;
+	ReadTimeVal.tv_sec = 1;
+	ReadTimeVal.tv_usec = 0;
+	fd_set ReadFdSet;
+	FD_ZERO(&ReadFdSet);
+	FD_SET(TCPListenServer, &ReadFdSet);
+	select(TCPListenServer+1, &ReadFdSet, NULL, NULL, &ReadTimeVal);
+
+	static struct sockaddr_in servaddr;
+	unsigned size = sizeof(servaddr);
+	TcpConnectionSocket = accept(TCPListenServer,
+	                             (struct sockaddr *)&servaddr,
+	                             &size);
+
+	if (TcpConnectionSocket < 0) return false;
+
+	setState(TcpRead, TCP_WAIT_ON_START);
+	debug_printf("Connected to %s:%d",
+	             inet_ntoa(servaddr.sin_addr),
+	             ntohs(servaddr.sin_port));
+	return true;
+}
+
+static void hexdump(uint8_t *buf, unsigned len) {
+	const unsigned bpl = 8;
+	const unsigned spc = 2;
+	char out[bpl*4 + spc + 1];
+	int outpos = 0;
+	memset(out, ' ', sizeof(out));
+	out[sizeof(out)-1] = 0;
+
+	for (unsigned i = 0; i < len; i++) {
+		sprintf(out+outpos, "%02x ", buf[i]);
+		char c = buf[i];
+		if (!isgraph(c)) c = '.';
+		out[(bpl*3)+spc+(outpos/3)] = c;
+		outpos += 3;
+		if (i%bpl == (bpl-1) || i+1 == len) {
+			out[outpos] = ' ';
+			debug_printf("%04x  %s", i-bpl+1, out);
+			memset(out, ' ', sizeof(out)-1);
+			outpos = 0;
+		}
+	}
+}
+
+static uint32_t cNetWriteTcp(uint8_t *Buffer, uint32_t Length) {
+	if (Length < 1) return 0;
+	if (State.NetConnection != TCP_CONNECTED) return 0;
+
+	hexdump(Buffer, Length);
+	return write(TcpConnectionSocket, Buffer, Length);
+}
+
+static uint32_t cNetReadTcp(uint8_t *Buffer, uint32_t Length) {
+	int DataRead = 0; // Nothing read also sent if NOT initiated
+	switch (State.TcpRead) {
+	case TCP_IDLE: // Do Nothing
+		break;
+
+	case TCP_WAIT_ON_START:
+		debug_printf("TCP_WAIT_ON_START:");
+
+		DataRead = read(TcpConnectionSocket, Buffer, 100); // Fixed TEXT
+
+		debug_printf("DataRead = %d, Buffer = ", DataRead);
+		hexdump(Buffer, DataRead);
+
+		if (DataRead == 0) {
+			cNetTcpClose();
+			break;
+		}
+
+		if (strstr((char *)Buffer, "ET /target?sn=")) {
+			debug_printf("TCP_WAIT_ON_START and ET /target?sn= found.");
+
+			// A match found => UNLOCK
+			// Say OK back
+			cNetWriteTcp((uint8_t*)"Accept:EV340\r\n\r\n", 16);
+			setState(TcpRead, TCP_WAIT_ON_LENGTH);
+		}
+
+		DataRead = 0; // No COM-module activity yet
+		break;
+
+	case TCP_WAIT_ON_LENGTH:
+		debug_printf("TCP_WAIT_ON_LENGTH:");
+		assert(Length >= 2 && "Buffer too small");
+
+		TcpReadBufPointer = 0; // Begin on new buffer
+
+		DataRead = read(TcpConnectionSocket, Buffer, 2);
+
+		debug_printf("DataRead = %d", DataRead);
+		if (DataRead < 2) {
+			cNetTcpClose();
+			break;
+		}
+
+		TcpRestLen = (uint32_t)(Buffer[0] + Buffer[1] * 256);
+		TcpTotalLength = (uint32_t)(TcpRestLen + 2);
+		setState(TcpRead, TCP_WAIT_ON_ONLY_CHUNK);
+
+		TcpReadBufPointer += DataRead;
+		DataRead = 0; // Signal NO data yet
+
+		debug_printf("*************** NEW TX *************");
+		debug_printf("TcpRestLen = %d, Length = %d", TcpRestLen, Length);
+
+		break;
+
+	case TCP_WAIT_ON_ONLY_CHUNK:
+		debug_printf("TCP_WAIT_ON_ONLY_CHUNK: BufferStart = %d",
+		             TcpReadBufPointer);
+		assert(Length >= TcpTotalLength && "Buffer too small!");
+
+		DataRead = read(TcpConnectionSocket,
+		                &(Buffer[TcpReadBufPointer]),
+		                TcpRestLen);
+
+		debug_printf("DataRead = %d", DataRead);
+		debug_printf("BufferPointer = %p", &(Buffer[TcpReadBufPointer]));
+
+		if (DataRead == 0) {
+			cNetTcpClose();
+			break;
+		}
+
+		TcpReadBufPointer += DataRead;
+
+		if (TcpRestLen == (unsigned)DataRead) {
+			DataRead = TcpTotalLength; // Total count read
+			setState(TcpRead, TCP_WAIT_ON_LENGTH);
+		} else {
+			TcpRestLen -= DataRead; // Still some bytes in this chunk
+			DataRead = 0; // No COMM job yet
+		}
+
+		hexdump(Buffer, TcpTotalLength);
+
+		debug_printf("TcpRestLen = %d, DataRead = %d, Length = %d",
+		             TcpRestLen, DataRead, Length);
+		break;
+
+	default: // Should never go here....
+		setState(TcpRead, TCP_IDLE);
+		break;
+	}
+	return DataRead;
+}
+
+
+static void cNetTransmitBeacon(void) {
+	if (cNetCheckTimer() < BEACON_TIME) return;
+
+	char Buffer[1024];
+
+	static struct sockaddr_in ServerAddr;
+	memset(&ServerAddr, 0, sizeof(ServerAddr));
+	ServerAddr.sin_family = AF_INET;
+	ServerAddr.sin_port = htons(BROADCAST_PORT);
+	ServerAddr.sin_addr.s_addr = inet_addr(BROADCAST_ADDRESS);
+
+	sprintf(Buffer,
+	        "Serial-Number: %s\r\nPort: %d\r\nName: %s\r\nProtocol: "
+	        "EV3\r\n",
+	        "31337", TCP_PORT, BRICK_NAME);
+
+	int UdpTxCount = sendto(UdpSocketDescriptor, Buffer, strlen(Buffer), 0,
+	                    (struct sockaddr *)&ServerAddr, sizeof(ServerAddr));
+	debug_printf("UDP BROADCAST to port %d, address %s => %d",
+	             ntohs(ServerAddr.sin_port),
+	             inet_ntoa(ServerAddr.sin_addr),
+	             UdpTxCount);
+	if (UdpTxCount < 0) cNetUdpClose();
+	cNetStartTimer();
+}
+
+static bool cNetInitUdp(void) {
+	/* Get a socket descriptor for UDP client (Beacon) */
+	if ((UdpSocketDescriptor = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+		debug_printf("UDP socket() error");
+		return false;
+	}
+
+	debug_printf("UDP socket() OK, Broadcast to %s", BROADCAST_ADDRESS);
+	static int BroadCast = 1;
+	if (setsockopt(UdpSocketDescriptor, SOL_SOCKET,
+	               SO_BROADCAST, &BroadCast, sizeof(BroadCast)) < 0) {
+		debug_printf("Could not setsockopt SO_BROADCAST");
+		return false;
+	}
+
+	int Temp = fcntl(UdpSocketDescriptor, F_GETFL, 0);
+	fcntl(UdpSocketDescriptor, F_SETFL, Temp | O_NONBLOCK);
+
+	cNetTransmitBeacon();
+	setState(NetConnection, TCP_NOT_CONNECTED);
+
+	return true;
+}
+
+int bridgeMode() {
+	if (!cNetInitUdp()) return ERR_IO;
+	if (!cNetInitTcpServer()) return ERR_IO;
+
+	static uint8_t ReadBuf[65540] = {0};
+	static uint8_t WriteBuf[65540] = {0};
+	int write_len = 0, write_pos = 0;
+
+	while (State.NetConnection != CLOSED) {
+		switch (State.NetConnection) {
+		case TCP_NOT_CONNECTED:
+			cNetTransmitBeacon();
+
+			if (cNetWaitForTcpConnection()) {
+				setState(NetConnection, TCP_CONNECTED);
+			}
+			break;
+
+		case TCP_CONNECTED: {
+			if (write_len <= 0) {
+				write_len = ev3_read_timeout(handle, WriteBuf, sizeof(WriteBuf), 0);
+				write_pos = 0;
+				if (write_len) {
+					int realLen = WriteBuf[0] + 256*WriteBuf[1] + 2;
+					assert(realLen <= write_len);
+					write_len = realLen;
+					debug_printf("ev3_read returned %i", write_len);
+				}
+			}
+
+			struct timeval timeout;
+			timeout.tv_sec = 0;
+			timeout.tv_usec = 100000;
+			fd_set ReadFdSet, WriteFdSet;
+			FD_ZERO(&ReadFdSet);
+			FD_SET(TcpConnectionSocket, &ReadFdSet);
+			FD_ZERO(&WriteFdSet);
+			if (write_len > 0) FD_SET(TcpConnectionSocket, &WriteFdSet);
+
+			select(TcpConnectionSocket+1, &ReadFdSet, &WriteFdSet, NULL, &timeout);
+
+			if (FD_ISSET(TcpConnectionSocket, &ReadFdSet)) {
+				int len = cNetReadTcp(ReadBuf+1, sizeof(ReadBuf)-1);
+				if (len > 0) {
+					int err = ev3_write(handle, ReadBuf, len+1);
+					debug_printf("ev3_write for %i returned %i", len, err);
+					if (err < len+1) {
+						cNetTcpClose();
+						break;
+					}
+				}
+			}
+			if (FD_ISSET(TcpConnectionSocket, &WriteFdSet)) {
+				int written = cNetWriteTcp(WriteBuf+write_pos, write_len);
+				if (written > 0) {
+					write_len -= written;
+					write_pos += written;
+				}
+			}
+
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	cNetTcpClose();
+	cNetUdpClose();
+	return ERR_UNK;
+}

--- a/src/bt-unix.c
+++ b/src/bt-unix.c
@@ -73,7 +73,7 @@ int bt_write(void* fd_, const u8* buf, size_t count)
  * \param [in] milliseconds number of milliseconds to wait at maximum. -1 is indefinitely
  * \return status -1 on error. bytes read otherwise.	
  * \brief writes buf[1] till buf[count - 2] to device
- * \bug timeout only applies to first byte read; once something is read, the whole packed is read in a blocking way
+ * \bug timeout only applies to first byte read; once something is read, the whole packet is read in a blocking way
  */
 int bt_read(void* fd_, u8* buf, size_t count, int milliseconds)
 {

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -53,8 +53,8 @@ extern int mkdir(const char *rem);
 extern size_t mkrbf(char **buf, const char *cmd);
 
 //! tunnel stdio to established ev3 connection
-extern int tunnel();
-extern int listen();
+extern int tunnelMode();
+extern int listenMode();
 
 
 #if 0 // not yet implemented

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -55,6 +55,7 @@ extern size_t mkrbf(char **buf, const char *cmd);
 //! tunnel stdio to established ev3 connection
 extern int tunnelMode();
 extern int listenMode();
+extern int bridgeMode();
 
 
 #if 0 // not yet implemented

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -53,9 +53,9 @@ extern int mkdir(const char *rem);
 extern size_t mkrbf(char **buf, const char *cmd);
 
 //! tunnel stdio to established ev3 connection
-extern int tunnelMode();
-extern int listenMode();
-extern int bridgeMode();
+extern int tunnel_mode();
+extern int listen_mode();
+extern int bridge_mode();
 
 
 #if 0 // not yet implemented

--- a/src/listen.c
+++ b/src/listen.c
@@ -4,7 +4,7 @@
 #include "defs.h"
 #include "ev3_io.h"
 
-int listen()
+int listenMode()
 {
 	u8 buffer[1280] = {0};
 	int read;

--- a/src/listen.c
+++ b/src/listen.c
@@ -4,7 +4,7 @@
 #include "defs.h"
 #include "ev3_io.h"
 
-int listenMode()
+int listen_mode()
 {
 	u8 buffer[1280] = {0};
 	int read;

--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,11 @@ const char* const usage =
     "USAGE: ev3duder " "[ --tcp | --usb | --serial ] [=dev1,dev2] \n"
     "                " "[ up loc rem | dl rem loc | rm rem | ls [rem] |\n"
     "                " "  mkdir rem | mkrbf rem loc | run rem | exec cmd |\n"
+#ifdef BRIDGE_MODE
     "                " "  wpa2 SSID [pass] | info | tunnel | bridge ]\n"
+#else
+    "                " "  wpa2 SSID [pass] | info | tunnel ]\n"
+#endif
     "       "
     "rem = remote (EV3) path, loc = local path, dev = device identifier"	"\n";
 const char* const usage_desc =
@@ -81,7 +85,9 @@ const char* const usage_desc =
     "exec\t"	"pass cmd to root shell. Handle with caution\n"
     "wpa2\t"	"connect to WPA-Network SSID, if pass isn't specified, read from stdin\n"
     "tunnel\t"	"connects stdout/stdin to the ev3 VM\n"
-    "bridge\t"	"simulates a WiFi-connected device bridged to the real ev3 VM\n"
+#ifdef BRIDGE_MODE
+    "bridge\t"	"simulates a WiFi-connected device bridged to a real ev3 VM\n"
+#endif
     ;
 
 #define FOREACH_ARG(ARG) \
@@ -323,13 +329,18 @@ int main(int argc, char *argv[])
         ret = ls(argv[0] ?: "/");
         break;
     case ARG_tunnel:
-        ret = tunnelMode();
+        ret = tunnel_mode();
         break;
     case ARG_listen:
-        ret = listenMode();
+        ret = listen_mode();
         break;
     case ARG_bridge:
-        ret = bridgeMode();
+#ifdef BRIDGE_MODE
+        ret = bridge_mode();
+#else
+        puts(usage);
+        return ERR_ARG;
+#endif
         break;
     case ARG_send:
         ;

--- a/src/main.c
+++ b/src/main.c
@@ -321,10 +321,10 @@ int main(int argc, char *argv[])
         ret = ls(argv[0] ?: "/");
         break;
     case ARG_tunnel:
-        ret = tunnel();
+        ret = tunnelMode();
         break;
     case ARG_listen:
-        ret = listen();
+        ret = listenMode();
         break;
     case ARG_send:
         ;

--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,7 @@ const char* const usage =
     "USAGE: ev3duder " "[ --tcp | --usb | --serial ] [=dev1,dev2] \n"
     "                " "[ up loc rem | dl rem loc | rm rem | ls [rem] |\n"
     "                " "  mkdir rem | mkrbf rem loc | run rem | exec cmd |\n"
-    "                " "  wpa2 SSID [pass] | info | tunnel ]\n"
+    "                " "  wpa2 SSID [pass] | info | tunnel | bridge ]\n"
     "       "
     "rem = remote (EV3) path, loc = local path, dev = device identifier"	"\n";
 const char* const usage_desc =
@@ -81,6 +81,7 @@ const char* const usage_desc =
     "exec\t"	"pass cmd to root shell. Handle with caution\n"
     "wpa2\t"	"connect to WPA-Network SSID, if pass isn't specified, read from stdin\n"
     "tunnel\t"	"connects stdout/stdin to the ev3 VM\n"
+    "bridge\t"	"simulates a WiFi-connected device bridged to the real ev3 VM\n"
     ;
 
 #define FOREACH_ARG(ARG) \
@@ -93,6 +94,7 @@ ARG(rm)              \
 ARG(mkdir)           \
 ARG(mkrbf)           \
 ARG(tunnel)			\
+ARG(bridge)			\
 ARG(listen)			\
 ARG(send)			\
 ARG(exec)            \
@@ -325,6 +327,9 @@ int main(int argc, char *argv[])
         break;
     case ARG_listen:
         ret = listenMode();
+        break;
+    case ARG_bridge:
+        ret = bridgeMode();
         break;
     case ARG_send:
         ;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -31,8 +31,8 @@ static int hex2nib(char hex);
  *
  *	- If stdio is connected to a terminal, packets can be entered in hex and submitted with a line break. non-graphical characters, including whitespace, are ignored. If the first 4 bytes can't be parsed as hex digits, they are replaced with the binary length. Any other character is replaced with a nibble rounded up.
  *	- If stdio is a pipe, the first 2 bytes are read to acquire packet length and then an equal amount of bytes is read and sent to the ev3
- */ 
-int tunnel()
+ */
+int tunnelMode()
 {
 	int res;
 	(void)res;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -32,7 +32,7 @@ static int hex2nib(char hex);
  *	- If stdio is connected to a terminal, packets can be entered in hex and submitted with a line break. non-graphical characters, including whitespace, are ignored. If the first 4 bytes can't be parsed as hex digits, they are replaced with the binary length. Any other character is replaced with a nibble rounded up.
  *	- If stdio is a pipe, the first 2 bytes are read to acquire packet length and then an equal amount of bytes is read and sent to the ev3
  */
-int tunnelMode()
+int tunnel_mode()
 {
 	int res;
 	(void)res;


### PR DESCRIPTION
These commits add a new operating mode that create a virtual brick connected via TCP (on localhost) that just passes data through from/to a real EV3 brick, e.g. on USB.

Run it like ```ev3duder --usb bridge```, then run the original Mindstorms software via Wine and it should show a WiFi-connected device called "USB Bridge". Setting up Mindstorms on Wine is non-trivial, but this allows working with a USB-connected brick.