### PR TITLE
feat: rework ls command

### DIFF
--- a/src/ls.c
+++ b/src/ls.c
@@ -15,45 +15,40 @@
 #include "funcs.h"
 
 /**
- * @brief List files and directories at \p path. path is always relative to <em>/home/root/lms2012/prjs/sys/<em>
+ * @brief List files and directories at \p path. Non-absolute paths are relative to <em>/home/root/lms2012/prjs/sys/</em>
  * @param [in] loc Local FILE*s
  * @param [in] rem Remote EV3 UTF-8 encoded path strings
  *
  * @retval error according to enum #ERR
  * @see http://topikachu.github.io/python-ev3/UIdesign.html
- * @warning Doesn't handle replies over 1014 byte in length.
- *      implementation of \p CONTINUTE_LIST_FILES isn't tested
- *		because CONTINUE_LIST_FILES isn't implemented in "firmware".
- * @warning ls /proc will lock up the virtual machine. 
+ * @warning ls /proc will lock up the virtual machine (reading from /proc/kmsg locks up the VM).
  * So refrain from doing it or exposing it to the user
  * The Eclipse Plugin handles /proc specially by making it non expandable
- * in the file manager 
+ * in the file manager
  */
-
-#define MAX_READ 1024
 
 int ls(const char *path)
 {
 	int res;
 	size_t path_sz = strlen(path) + 1;
+
 	LIST_FILES *list = packet_alloc(LIST_FILES, path_sz);
-	list->maxBytes = MAX_READ;
 	memcpy(list->path, path, path_sz);
+	list->maxBytes = 1024 - sizeof(LIST_FILES_REPLY);
 
-	print_bytes(list, list->packetLen + PREFIX_SIZE);
-
+	//print_bytes(list, list->packetLen + PREFIX_SIZE);
 	res = ev3_write(handle, (u8 *) list, list->packetLen + PREFIX_SIZE);
 	if (res < 0)
 	{
 		errmsg = "Unable to write LIST_FILES.";
 		return ERR_COMM;
 	}
+	size_t file_chunksz = 1024;
+	void *file_chunk = malloc(file_chunksz);
 
-	fputs("Checking reply: \n", stderr);
-	size_t listrep_sz = sizeof(LIST_FILES_REPLY) + list->maxBytes;
-	LIST_FILES_REPLY *listrep = calloc(listrep_sz, 1);
+	LIST_FILES_REPLY *listrep = file_chunk;
 
-	res = ev3_read_timeout(handle, (u8 *) listrep, listrep_sz, TIMEOUT);
+	res = ev3_read_timeout(handle, (u8 *) listrep, file_chunksz, TIMEOUT);
 	if (res <= 0)
 	{
 		errmsg = "Unable to read LIST_FILES";
@@ -66,40 +61,33 @@ int ls(const char *path)
 		fputs("Operation failed.\nlast_reply=", stderr);
 		print_bytes(listrep, listrep->packetLen);
 
+
 		errmsg = "`LIST_FILES` was denied.";
 		return ERR_VM;
 	}
+	unsigned read_so_far = listrep->packetLen + 2 - (unsigned) offsetof(LIST_FILES_REPLY, list);
+	fwrite(listrep->list, read_so_far, 1, stdout);
 
-	fwrite(listrep->list, 1, listrep->packetLen - 10 <= MAX_READ ? listrep->packetLen - 10 : 1024,
-		   stdout); // No NUL Termination over Serial COM for whatever reason.
+	unsigned total = listrep->listSize;
 
-	//
-	// Excerpt from the lms2012O sources:  - LIST_FILES should work as long as list does not exceed 1014 bytes.
-	// CONTINUE_LISTFILES has NOT been implemented yet.
-#if LEGO_FIXED_CONTINUE_LIST_FILES
-	size_t read_so_far = listrep->packetLen + 2 - offsetof(LIST_FILES_REPLY, list);
-	size_t total = listrep->listSize;
 	CONTINUE_LIST_FILES listcon = CONTINUE_LIST_FILES_INIT;
-	listcon.handle =listrep->handle;
-	listcon.listSize = 100;
-	//	fprintf(stderr, "read %zu from total %zu bytes.\n", read_so_far, total);
-	size_t listconrep_sz = sizeof(CONTINUE_LIST_FILES_REPLY) + MAX_READ;
-	CONTINUE_LIST_FILES_REPLY *listconrep = malloc(listconrep_sz);
-	int ret = listconrep->ret;
-	while(ret != END_OF_FILE)
+	listcon.handle = listrep->handle;
+	listcon.listSize = file_chunksz - sizeof(CONTINUE_LIST_FILES_REPLY);
+	//fprintf(stderr, "read %u from total %u bytes.\n", read_so_far, total);
+	CONTINUE_LIST_FILES_REPLY *listconrep = file_chunk;
+	while (read_so_far < total)
 	{
-		CONTINUE_LIST_FILES_REPLY *listconrep = malloc(listconrep_sz);
-		res = ev3_write(handle, (u8*)&listcon, sizeof listcon);
+		res = ev3_write(handle, (u8 *) &listcon, sizeof listcon);
 		if (res < 0)
 		{
-			errmsg = "Unable to write LIST_FILES";
+			errmsg = "Unable to write CONTINUE_LIST_FILES";
 			return ERR_COMM;
 		}
 
-		res = ev3_read_timeout(handle, (u8 *)listconrep, listconrep_sz, TIMEOUT);
+		res = ev3_read_timeout(handle, (u8 *) listconrep, file_chunksz, TIMEOUT);
 		if (res <= 0)
 		{
-			errmsg = "Unable to read LIST_FILES_REPLY";
+			errmsg = "Unable to read CONTINUE_LIST_FILES_REPLY";
 			return ERR_COMM;
 		}
 		if (listconrep->type == VM_ERROR)
@@ -108,19 +96,16 @@ int ls(const char *path)
 			fputs("Operation failed.\nlast_reply=", stderr);
 			print_bytes(listconrep, listconrep->packetLen);
 
-
-			errmsg = "`LIST_FILES` was denied.";
+			errmsg = "`CONTINUE_LIST_FILES` was denied.";
 			return ERR_VM;
 		}
-		fprintf(stdout, "%s", listconrep->list);
-		listcon.handle = listconrep->handle;
-		listcon.listSize = MAX_READ;
-		size_t read_so_far = listconrep->packetLen + 2 - offsetof(CONTINUE_LIST_FILES_REPLY, list);
+		size_t read_this_time = listconrep->packetLen + 2 - offsetof(CONTINUE_LIST_FILES_REPLY, list);
+		fwrite(listconrep->list, read_this_time, 1, stdout);
 		fflush(stdout);
-		//fprintf(stderr, "read %zu from total %zu bytes.\n", read_so_far, listconrep_sz);
-		ret = listconrep->ret;
+		listcon.handle = listconrep->handle;
+		read_so_far += read_this_time;
+		//fprintf(stderr, "read %u from total %u bytes.\n", read_so_far, total);
 	}
-#endif
 
 	errmsg = "`LIST_FILES` was successful.";
 	return ERR_UNK;


### PR DESCRIPTION
It appears that ls and dl should use the same algorithm for fetching data from the brick. Also, as CONTINUE_LIST_FILES is implemented in new EV3 firmwares, it is possible to reuse a the download algorithm for full ls implementation. This PR makes the ls and dl source code almost identical.

I have tested the changes against the stock 1.10E firmware and it seems to work correctly. If there is a regression, it should only trigger on directories with >1012 byte directory listings, as only then the CONTINUE_LIST_FILES command is issued.

Fixes https://github.com/c4ev3/ev3duder/issues/18