### PR TITLE
fix(bt): write loop: advance pointer by sent bytes

### DIFF
--- a/src/bt-unix.c
+++ b/src/bt-unix.c
@@ -61,7 +61,7 @@ int bt_write(void *fd_, const u8 *buf, size_t count)
 	size_t sent;
 	for (ssize_t ret = sent = 0; sent < count; sent += ret)
 	{
-		ret = write(fd, buf, count - sent);
+		ret = write(fd, buf + sent, count - sent);
 		if (ret == -1)
 		{
 			// set some error msg


### PR DESCRIPTION
There is a hidden bug in the bluetooth write loop - the input buffer pointer is not advanced. If the write() was short, the end of the buffer wouldn't get written to the device.