### PR TITLE
fix(tcp): fix ws2tcpip.h header name case

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -8,7 +8,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 
 #define bailout(msg) ({\
 	char *buf; \


### PR DESCRIPTION
With this change, it is possible to successfully compile Windows binaries using standard Ubuntu mingw-w64 compilers.