### PR TITLE
fix(flash): fix broken flashing on usb 3.0+

### DIFF
--- a/src/bl_exit.c
+++ b/src/bl_exit.c
@@ -49,6 +49,6 @@ int bootloader_exit(void)
 		return ERR_VM;
 	}
 
-	errmsg = "`FW_STARTAPP` was successful.";
+	errmsg = "Update mode was exited successfully.";
 	return ERR_UNK;
 }

--- a/src/bl_exit.c
+++ b/src/bl_exit.c
@@ -38,10 +38,8 @@ int bootloader_exit(void)
 		return ERR_COMM;
 	}
 
-	if (reply->type == VM_SYS_RQ)
-		return ERR_USBLOOP;
-
-	if (reply->type != VM_OK)
+	// note: accept looped-back packets (usb 3.0 bug; reply not required here)
+	if (reply->type != VM_OK && reply->type != VM_SYS_RQ)
 	{
 		errno = reply->ret;
 		fputs("Operation failed.\nlast_reply=", stderr);

--- a/src/bl_exit.c
+++ b/src/bl_exit.c
@@ -49,6 +49,8 @@ int bootloader_exit(void)
 		return ERR_VM;
 	}
 
+	puts("\nNote: if your EV3 isn't detected as a USB device now, try restarting the brick from its menu.\n");
+
 	errmsg = "Update mode was exited successfully.";
 	return ERR_UNK;
 }

--- a/src/bl_info.c
+++ b/src/bl_info.c
@@ -52,6 +52,7 @@ int bootloader_info(void)
 		return ERR_COMM;
 	}
 
+	// forbid looped-back packets (usb 3.0 bug; reply *is* required here)
 	if (reply->type == VM_SYS_RQ)
 		return ERR_USBLOOP;
 


### PR DESCRIPTION
This fixes https://github.com/c4ev3/ev3duder/issues/32 by not exiting prematurely when an echoed response from the brick is detected. This seems to be how the official EV3 software handles this on Windows.

With this PR, flashing on USB 3.0 should finally be possible.
