### PR TITLE
docs(readme): add info about git submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ On Linux, you additionally need libudev-dev to be installed. On Ubuntu and other
 
     $ sudo apt-get install libudev-dev
 
+If you used only a simple `git clone` earlier, you may also need to download some missing git modules:
+
+    $ git submodule update --init --recursive
+
 Also to allow access to the ev3 over USB without requiring root, appropriate udev rules must be created. This can be easily done with
 
     $ make install


### PR DESCRIPTION
Addresses https://github.com/c4ev3/ev3duder/pull/33#issuecomment-763104264. I was also confused for a while why the signal11 hidapi library is missing.