### PR TITLE
feat(flash): Add "flash crc" command

### DIFF
--- a/src/bl_install.c
+++ b/src/bl_install.c
@@ -6,6 +6,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #include <errno.h>
 
@@ -45,10 +46,6 @@ static int bootloader_send(FILE *fp, int length, u32* pCrc32);
  * @retval error according to enum #ERR
  */
 static int bootloader_checksum(int offset, int length, u32 *pCrc32);
-
-/* this matches LEGO FW sizes */
-#define FLASH_START 0x00000000
-#define FLASH_SIZE (16 * 1000 * 1024)
 
 /**
  * @brief Install new firmware binary to the internal flash.
@@ -236,6 +233,79 @@ static int bootloader_send(FILE *fp, int length, u32* pCrc32)
 	}
 	*pCrc32 = crc;
 	return ERR_UNK;
+}
+
+/**
+ * @brief Compare CRCs of the flash memory and the firmware image.
+ * @param fp Firmware file that is supposed to be flashed in the brick.
+ * @param starting_sector First 64 KiB sector of the flash memory to check (0-based)
+ * @param num_sectors Number of 64 KiB sectors to check
+ * @param verbose If true, CRC is checked for each sector individually.
+ *                Otherwise, it is computed across all sectors at once.
+ * @retval error according to enum #ERR
+ */
+int bootloader_crc(FILE *fp, u32 starting_sector, u32 num_sectors, bool verbose)
+{
+	u8 *firmware = calloc(FLASH_SIZE, 1);
+	if (!firmware) {
+		errmsg = "out of memory";
+		return ERR_NOMEM;
+	}
+	u32 read_bytes = fread(firmware, 1, FLASH_SIZE, fp);
+	if (ferror(fp)) {
+		errmsg = "Reading of firmware file failed";
+		free(firmware);
+		return ERR_IO;
+	}
+	u32 wanted_bytes = (starting_sector + num_sectors) * FLASH_SECTOR_SIZE;
+	if (read_bytes < wanted_bytes) {
+		printf("WARNING: firmware file is truncated: %d bytes expected, %d bytes read\n", wanted_bytes, read_bytes);
+	}
+
+	int err = ERR_UNK;
+	if (verbose) {
+		// Sector-by-sector CRC comparison.
+		// Compares the remote and local CRCs of each sector, showing the results of each.
+		printf("Sector CRC comparison:\n");
+		bool all_ok = true;
+		for (u32 sector = starting_sector; sector < starting_sector + num_sectors; sector++) {
+			u32 local_sector_crc32 = crc32(0, firmware + sector * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
+			u32 remote_sector_crc32 = 0;
+			int sector_err = bootloader_checksum(sector * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE, &remote_sector_crc32);
+
+			bool this_ok = remote_sector_crc32 == local_sector_crc32;
+			all_ok = all_ok && this_ok;
+
+			if (sector_err == ERR_UNK) {
+				printf("Sector %3d: Remote CRC = %08X, local CRC = %08X%s\n", sector, remote_sector_crc32,
+					local_sector_crc32, this_ok ? "" : " ERR");
+			} else {
+				printf("Error requesting sector CRC.  Err = %i\n", sector_err);
+				err = sector_err;
+			}
+		}
+
+		if (all_ok) {
+			puts("All sectors match.");
+		} else {
+			puts("Some sectors do not match.");
+		}
+	} else {
+		// Do a single comparison, calculating the CRC over multiple sectors.
+		u32 local_crc32 = crc32(0, firmware + starting_sector * FLASH_SECTOR_SIZE, num_sectors * FLASH_SECTOR_SIZE);
+		printf("Requesting remote CRC...\n");
+		u32 remote_crc32 = 0;
+		err = bootloader_checksum(starting_sector * FLASH_SECTOR_SIZE, num_sectors * FLASH_SECTOR_SIZE, &remote_crc32);
+		if (err == ERR_UNK) {
+			printf("Remote CRC = %08X, local CRC = %08X%s\n", remote_crc32, local_crc32,
+				remote_crc32 == local_crc32 ? "" : " ERR");
+		} else {
+			printf("Error requesting full CRC.  Err = %i\n", err);
+		}
+	}
+
+	free(firmware);
+	return err;
 }
 
 static int bootloader_checksum(int offset, int length, u32 *pCrc32)

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -17,6 +17,8 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <stdbool.h>
+
 /**
  * @name    General Usage
  * @ingroup EV3 commands
@@ -70,6 +72,18 @@ extern int bootloader_enter(void);
 
 //! install new firmware to the brick
 extern int bootloader_install(FILE *fp);
+
+// First address of EV3 flash memory
+#define FLASH_START 0x00000000
+// Size of EV3 flash memory in bytes
+#define FLASH_SIZE (16 * 1000 * 1024)
+// Size of EV3 flash memory erase block
+#define FLASH_SECTOR_SIZE (64*1024) // N25Q128 datasheet says that it has 64-Kbyte sectors/eraseblocks
+// Number of sectors in EV3 flash memory
+#define FLASH_SECTOR_COUNT (FLASH_SIZE / FLASH_SECTOR_SIZE)
+
+//! compare device CRC to CRC from a file
+extern int bootloader_crc(FILE *fp, u32 starting_sector, u32 num_sectors, bool verbose);
 
 //! print brick hardware version
 extern int bootloader_info(void);

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <stdbool.h>
 
 #include <hidapi/hidapi.h>
 
@@ -154,6 +155,9 @@ const char *const usage_desc = "Info:\n"
 		"flash install   install the given firmware file to the EV3\n"
 		"flash info      show hardware and EEPROM versions\n"
 		"flash exit      exit from the firmware update mode without installing new firmware\n"
+		"flash crc       compares CRCs of the given firmware file and the EV3 installed firmware\n"
+		"flash crc f n   compares file/EV3 CRCs of a block of n 64k sectors, starting at sector #f (zero-based). Full size is 250 sectors.\n"
+		"flash crc f n v verbose (sector-by-sector) file/EV3 CRC comparison, starting at sector #f (zero-based) and doing n sectors (max 250).\n"
 		"uf2 pack        pack files into a Microsoft UF2 container\n"
 		"                note: common brickdir options are: \n"
 		"                'Projects' (internal flash, default), 'SD Card', 'USB Stick',\n"
@@ -655,6 +659,43 @@ int main(int argc, char *argv[])
 				}
 
 				ret = bootloader_install(fp);
+
+			} else if (strcmp(argv[0], "crc") == 0) {
+				// ev3duder --usb flash crc firmware.bin          Full CRC comparison
+				// ev3duder --usb flash crc firmware.bin f n      CRC comparison of n sectors, starting at sector f (zero-based)
+				// ev3duder --usb flash crc firmware.bin f n v    Verbose comparison: compare CRC of every sector, showing the results
+				bool verbose = argc == 5 && strcmp(argv[4], "v") == 0;
+				if (argc == 2) {
+					fp = fopen(SANITIZE(argv[1]), "rb");
+					if (!fp) {
+						printf("File <%s> doesn't exist.\n", argv[1]);
+						return ERR_IO;
+					}
+					printf("Comparing full device CRCs...\n");
+					ret = bootloader_crc(fp, 0, FLASH_SECTOR_COUNT, false);
+
+				} else if (argc == 4 || verbose) {
+					u32 first_sector = atol(argv[2]);
+					if (first_sector >= FLASH_SECTOR_COUNT) first_sector = FLASH_SECTOR_COUNT - 1;
+					u32 num_sectors = atol(argv[3]);
+					if (num_sectors == 0) num_sectors = 1;	// Doesn't make sense to do zero.
+					if (first_sector + num_sectors > FLASH_SECTOR_COUNT) {
+						num_sectors = FLASH_SECTOR_COUNT - first_sector;
+					}
+					fp = fopen(SANITIZE(argv[1]), "rb");
+					if (!fp)
+					{
+						printf("File <%s> doesn't exist.\n", argv[1]);
+						return ERR_IO;
+					}
+					printf("Comparing CRCs of sectors %d - %d (%d sectors)\n", first_sector,
+						first_sector + num_sectors - 1, num_sectors);
+					ret = bootloader_crc(fp, first_sector, num_sectors, verbose);
+
+				} else {
+					ret = ERR_ARG;
+					printf("Expected either <filename> or <filename firstsector numsectors>\n");
+				}
 
 			} else if (strcmp(argv[0], "info") == 0) {
 				assert(argc == 1);


### PR DESCRIPTION
"flash crc" gives the user various ways of comparing the CRC of a file to the CRC reported by the EV3 bootloader.  Can do that for the full image, or a group of sectors, or sector-by-sector.

Credits go to @gtminch and so I have left him as the commit author. I have only picked the code up from https://github.com/JakubVanek/ev3duder/pull/1, cleaned it up slightly and separated it from the other flashing code changes.